### PR TITLE
Fix typo causing STRUCTURE mode not to do anything

### DIFF
--- a/src/cvsba.cpp
+++ b/src/cvsba.cpp
@@ -58,7 +58,7 @@ double  Sba::run ( std::vector<cv::Point3f>& points, //positions of points in gl
     //copy back if STRUCTURE enabled
 
     double err = run ( points_d, imagePoints_d, visibility, cameraMatrix, R, T, distCoeffs );
-    if ( _params.type == MOTION || _params.type == MOTIONSTRUCTURE )
+    if ( _params.type == STRUCTURE || _params.type == MOTIONSTRUCTURE )
         for ( size_t i = 0; i < points_d.size(); i++ )
             points[i] = cv::Point3f ( points_d[i].x, points_d[i].y, points_d[i].z );
     return err;

--- a/src/cvsba.h
+++ b/src/cvsba.h
@@ -31,7 +31,13 @@ namespace cvsba {
 class Sba {
 public:
 
+    // TYPE type: type of bundle adjustment optimization. Posible values:
+    // MOTIONSTRUCTURE: 3d points positions and camera extrinsic (R and T) are optimized. 
+    // Input is used as initial values.
+    // MOTION: just camera extrinsic are optimized, 3d points are fixed.
+    // STRUCTURE: just 3d points are optimized, camera extrinsic are fixed.
     enum TYPE {MOTIONSTRUCTURE = 0, MOTION, STRUCTURE };
+
     /**Params leading the optimization
      */
     struct Params {


### PR DESCRIPTION
The float version of "run" converts the points vector to double precision, runs SBA and converts the points back afterwards.
It has a check to only do the back-conversion in `STRUCTURE` or `MOTIONSTRUCTURE` mode, but the check was incorrect and checked for `MOTION` mode instead, thus throwing away the results when in `STRUCTURE` mode.