### PR TITLE
add __declspec to cvsba.h to support lib generation in windows

### DIFF
--- a/src/cvsba.h
+++ b/src/cvsba.h
@@ -26,9 +26,12 @@
 #include <vector>
 #include <iostream>
 #include <opencv2/core/core.hpp>
+
+#include "libcvsba_export.h"
+
 namespace cvsba {
 
-class __declspec(dllexport) Sba {
+class LIBCVSBA_EXPORT Sba {
 public:
 
     // TYPE type: type of bundle adjustment optimization. Posible values:

--- a/src/cvsba.h
+++ b/src/cvsba.h
@@ -28,7 +28,7 @@
 #include <opencv2/core/core.hpp>
 namespace cvsba {
 
-class Sba {
+class __declspec(dllexport) Sba {
 public:
 
     // TYPE type: type of bundle adjustment optimization. Posible values:

--- a/src/libcvsba_export.h
+++ b/src/libcvsba_export.h
@@ -1,0 +1,29 @@
+#ifndef LIBCVSBA_EXPORT_H
+#define LIBCVSBA_EXPORT_H
+
+
+#if defined(_MSC_VER) || defined(__CYGWIN__) || defined(__MINGW32__) || defined( __BCPLUSPLUS__) || defined( __MWERKS__)
+#   ifdef LIBCVSBA_STATIC_DEFINE
+#       define LIBCVSBA_EXPORT
+#       define LIBCVSBA_NO_EXPORT
+#   else
+#       ifndef LIBCVSBA_EXPORT
+#           ifdef LIBCVSBA_EXPORTS
+                /* We are building this library */
+#               define LIBCVSBA_EXPORT __declspec(dllexport)
+#           else
+                /* We are using this library */
+#               define LIBCVSBA_EXPORT __declspec(dllimport)
+#           endif
+#       endif
+
+#       ifndef LIBCVSBA_NO_EXPORT
+#           define LIBCVSBA_NO_EXPORT
+#       endif
+#   endif
+#else
+#   define LIBCVSBA_EXPORT
+#   define LIBCVSBA_NO_EXPORT
+#endif
+
+#endif


### PR DESCRIPTION
adds support for building the library on windows platform. In windows you need to specify which classes sould be exported to create the library file.